### PR TITLE
Feature: Option to enable auto-throwing of Result failures

### DIFF
--- a/QLoop.xcodeproj/project.pbxproj
+++ b/QLoop.xcodeproj/project.pbxproj
@@ -138,6 +138,10 @@
 		DCC759272241D04100B4750E /* QLoop+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC759262241D04100B4750E /* QLoop+ConvenienceInitTests.swift */; };
 		DCC759282241D04100B4750E /* QLoop+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC759262241D04100B4750E /* QLoop+ConvenienceInitTests.swift */; };
 		DCC759292241D04100B4750E /* QLoop+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC759262241D04100B4750E /* QLoop+ConvenienceInitTests.swift */; };
+		DCFACAEB22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */; };
+		DCFACAEC22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */; };
+		DCFACAED22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */; };
+		DCFACAEE22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -250,6 +254,7 @@
 		DCD9D7C3223DDE0900BBDEE2 /* QLoop.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = QLoop.md; sourceTree = "<group>"; };
 		DCD9D7C4223DDF8900BBDEE2 /* QLParallelSegment.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = QLParallelSegment.md; sourceTree = "<group>"; };
 		DCD9D7C5223DE0C800BBDEE2 /* QLSerialSegment.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = QLSerialSegment.md; sourceTree = "<group>"; };
+		DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ErrorGettable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -386,6 +391,7 @@
 				DC6FAF5D222F4EF5008BB070 /* QLAnchor.swift */,
 				DC5E449E224AFC2B0007FEAD /* QLAnchor+ConvenienceInit.swift */,
 				DC8F2B58223342E000277F70 /* QLPath.swift */,
+				DCFACAEA22D826C5004D6D7A /* Result+ErrorGettable.swift */,
 				DCF860BF2239D02B0018C1A1 /* Common */,
 				DC374A322231F28A006F1272 /* Iterating */,
 				DCA1FD232230C8E5006015BD /* Segment */,
@@ -740,6 +746,7 @@
 				DCA1FD1F2230C8DB006015BD /* QLSegment.swift in Sources */,
 				DC374A372231F2AD006F1272 /* QLoopIteratorContinueNilMax.swift in Sources */,
 				DCA1FD0C22303D22006015BD /* QLoop.swift in Sources */,
+				DCFACAEB22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */,
 				DC413D23223B191300000480 /* QLCommon.swift in Sources */,
 				DC6FAF5E222F4EF5008BB070 /* QLAnchor.swift in Sources */,
 				DC374A412231F361006F1272 /* QLoopIteratorContinueNil.swift in Sources */,
@@ -764,6 +771,7 @@
 				DCA1FD202230C8DB006015BD /* QLSegment.swift in Sources */,
 				DC374A342231F2AD006F1272 /* QLoopIteratorContinueNilMax.swift in Sources */,
 				DCA1FD0D22303D22006015BD /* QLoop.swift in Sources */,
+				DCFACAEC22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */,
 				DC413D24223B191300000480 /* QLCommon.swift in Sources */,
 				DC6FAF5F222F4EF5008BB070 /* QLAnchor.swift in Sources */,
 				DC374A3E2231F361006F1272 /* QLoopIteratorContinueNil.swift in Sources */,
@@ -788,6 +796,7 @@
 				DCA1FD212230C8DB006015BD /* QLSegment.swift in Sources */,
 				DC374A352231F2AD006F1272 /* QLoopIteratorContinueNilMax.swift in Sources */,
 				DCA1FD0E22303D22006015BD /* QLoop.swift in Sources */,
+				DCFACAED22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */,
 				DC413D25223B191300000480 /* QLCommon.swift in Sources */,
 				DC6FAF60222F4EF5008BB070 /* QLAnchor.swift in Sources */,
 				DC374A3F2231F361006F1272 /* QLoopIteratorContinueNil.swift in Sources */,
@@ -812,6 +821,7 @@
 				DCA1FD222230C8DB006015BD /* QLSegment.swift in Sources */,
 				DC374A362231F2AD006F1272 /* QLoopIteratorContinueNilMax.swift in Sources */,
 				DCA1FD0F22303D22006015BD /* QLoop.swift in Sources */,
+				DCFACAEE22D826C5004D6D7A /* Result+ErrorGettable.swift in Sources */,
 				DC413D26223B191300000480 /* QLCommon.swift in Sources */,
 				DC6FAF61222F4EF5008BB070 /* QLAnchor.swift in Sources */,
 				DC374A402231F361006F1272 /* QLoopIteratorContinueNil.swift in Sources */,

--- a/Sources/QLoop/Common/QLCommon.swift
+++ b/Sources/QLoop/Common/QLCommon.swift
@@ -11,6 +11,8 @@ public struct QLCommon {
                 return false
                 #endif
             }()
+
+            public static var autoThrowResultFailures: Bool = true
         }
     }
 

--- a/Sources/QLoop/Result+ErrorGettable.swift
+++ b/Sources/QLoop/Result+ErrorGettable.swift
@@ -1,0 +1,12 @@
+internal protocol ErrorGettable {
+    func getError() -> Error?
+}
+
+extension Result: ErrorGettable {
+    func getError() -> Error? {
+        if case let .failure(err) = self {
+            return err
+        }
+        return nil
+    }
+}

--- a/Tests/QLoopTests/QLAnchorTests.swift
+++ b/Tests/QLoopTests/QLAnchorTests.swift
@@ -21,21 +21,48 @@ final class QLAnchorTests: XCTestCase {
     func test_when_input_set_then_it_invokes_onChange() {
         var received: Int = -1
         let expect = expectation(description: "should set")
-
         let subject = QLAnchor<Int>(onChange: { received = $0!; expect.fulfill() })
+
         subject.value = 99
 
         wait(for: [expect], timeout: 8.0)
         XCTAssertEqual(received, 99)
     }
 
+    func test_when_input_set_is_result_error_then_it_invokes_onError_and_not_onChange() {
+        var receivedInput: Result<Int, Error>? = nil
+        var receivedError: Error? = nil
+        let expect = expectation(description: "should error")
+        let subject = QLAnchor<Result<Int, Error>>(onChange: { receivedInput = $0; expect.fulfill() },
+                                                   onError: { receivedError = $0; expect.fulfill() })
+
+        subject.value = .failure(QLCommon.Error.Unknown)
+
+        wait(for: [expect], timeout: 8.0)
+        XCTAssertNil(receivedInput)
+        XCTAssertNotNil(receivedError)
+    }
+
+    func test_when_input_set_is_result_value_then_it_invokes_onChange_and_not_onError_like_normal() {
+        var receivedInput: Result<Int, Error>? = nil
+        var receivedError: Error? = nil
+        let expect = expectation(description: "should value")
+        let subject = QLAnchor<Result<Int, Error>>(onChange: { receivedInput = $0; expect.fulfill() },
+                                                   onError: { receivedError = $0; expect.fulfill() })
+
+        subject.value = .success(11)
+
+        wait(for: [expect], timeout: 8.0)
+        XCTAssertNotNil(receivedInput)
+        XCTAssertNil(receivedError)
+    }
+
     func test_when_error_set_then_it_invokes_onError() {
         var receivedError: Error? = nil
         let expect = expectation(description: "should set")
-
         let subject = QLAnchor<Int>(onChange: { _ in },
                                     onError: { receivedError = $0; expect.fulfill() })
-        subject.onChange(nil)
+
         subject.error = QLCommon.Error.Unknown
 
         wait(for: [expect], timeout: 8.0)
@@ -45,10 +72,9 @@ final class QLAnchorTests: XCTestCase {
     func test_when_error_set_nil_then_it_invokes_onError_with_ErrorThrownButNotSet() {
         var receivedError: Error? = nil
         let expect = expectation(description: "should set")
-
         let subject = QLAnchor<Int>(onChange: { _ in },
                                     onError: { receivedError = $0; expect.fulfill() })
-        subject.onChange(nil)
+
         subject.error = nil
 
         wait(for: [expect], timeout: 8.0)


### PR DESCRIPTION
The way it works now, (or when using this in disabled mode once this gets merged), this is handled on a case-by-case basis within a given operation by unwrapping `Result`s using the built-in `get()` function, which either returns the value or throws on failure.

This PR makes it so that you don't have to do this case-by-case, and instead can have the built-in error propagation just handle it automatically without the boilerplate check.

Here, the `Anchor` checks if it's value is a `Result<_, Error>` and then looks for a .failure. If one is found, it will automatically reroute it down the error path so that any `errorHandler`s and/or `onError` triggers can catch them as expected.

This config will be enabled by default, but can be disabled using the `QLCommon.Config.Anchor.autoThrowResultFailures` global setting.